### PR TITLE
Re-enable add card button (market) after market clear

### DIFF
--- a/epc-ui.js
+++ b/epc-ui.js
@@ -209,6 +209,8 @@ function buildEpcUI(graphStyle) {
             } else {
                 $("#add-market-card-button").prop("disabled", false);
             }
+        } else {
+            $("#add-market-card-button").prop("disabled", false);
         }
     }
 


### PR DESCRIPTION
If market was maxed out, it would fail to re-enable this button